### PR TITLE
feat: allow to set a URI

### DIFF
--- a/lib/ZMQClient/ZMQClient.js
+++ b/lib/ZMQClient/ZMQClient.js
@@ -10,9 +10,14 @@ class ZMQClient extends EventEmitter {
    */
   constructor(options = {}) {
     super();
-    this.protocol = options.protocol || 'tcp';
-    this.host = options.host || '0.0.0.0';
-    this.port = options.port || '29998';
+    if(options.uri){
+      const [protocol, path] = options.uri.split('://');
+      const [host, port] = path.split(':');
+      return new ZMQClient({ host, port, protocol })
+    }
+    this.protocol = options?.protocol?.toString() || 'tcp';
+    this.host = options?.host?.toString() || '0.0.0.0';
+    this.port = options?.port?.toString() || '29998';
     this.isConnected = false;
   }
 }

--- a/lib/ZMQClient/ZMQClient.js
+++ b/lib/ZMQClient/ZMQClient.js
@@ -10,14 +10,15 @@ class ZMQClient extends EventEmitter {
    */
   constructor(options = {}) {
     super();
-    if(options.uri){
+    if (options.uri) {
       const [protocol, path] = options.uri.split('://');
       const [host, port] = path.split(':');
-      return new ZMQClient({ host, port, protocol })
+      return new ZMQClient({ host, port, protocol });
     }
-    this.protocol = options?.protocol?.toString() || 'tcp';
-    this.host = options?.host?.toString() || '0.0.0.0';
-    this.port = options?.port?.toString() || '29998';
+    this.protocol = (options && options.protocol) ? options.protocol.toString() : 'tcp';
+    this.host = (options && options.host) ? options.host.toString() : '0.0.0.0';
+    this.port = (options && options.port) ? options.port.toString() : '29998';
+
     this.isConnected = false;
   }
 }

--- a/lib/ZMQClient/ZMQClient.spec.js
+++ b/lib/ZMQClient/ZMQClient.spec.js
@@ -14,5 +14,25 @@ describe('ZMQClient', () => {
       expect(client.host).to.equal('0.0.0.0');
       expect(client.port).to.equal('29998');
     });
+    it('should allow to set protocol, host and port', function () {
+      const client = new ZMQClient({
+        protocol: 'tcp',
+        host: '1.1.1.1',
+        port: '20000',
+      });
+      expect(client.constructor).to.equal(ZMQClient);
+      expect(client.protocol).to.equal('tcp');
+      expect(client.host).to.equal('1.1.1.1');
+      expect(client.port).to.equal('20000');
+    });
+    it('should create from uri', () => {
+      const client = new ZMQClient({
+        uri: 'tcp://1.1.1.1:20000'
+      });
+      expect(client.constructor).to.equal(ZMQClient);
+      expect(client.protocol).to.equal('tcp');
+      expect(client.host).to.equal('1.1.1.1');
+      expect(client.port).to.equal('20000');
+    })
   });
 });

--- a/lib/ZMQClient/ZMQClient.spec.js
+++ b/lib/ZMQClient/ZMQClient.spec.js
@@ -14,7 +14,7 @@ describe('ZMQClient', () => {
       expect(client.host).to.equal('0.0.0.0');
       expect(client.port).to.equal('29998');
     });
-    it('should allow to set protocol, host and port', function () {
+    it('should allow to set protocol, host and port', () => {
       const client = new ZMQClient({
         protocol: 'tcp',
         host: '1.1.1.1',
@@ -27,12 +27,12 @@ describe('ZMQClient', () => {
     });
     it('should create from uri', () => {
       const client = new ZMQClient({
-        uri: 'tcp://1.1.1.1:20000'
+        uri: 'tcp://1.1.1.1:20000',
       });
       expect(client.constructor).to.equal(ZMQClient);
       expect(client.protocol).to.equal('tcp');
       expect(client.host).to.equal('1.1.1.1');
       expect(client.port).to.equal('20000');
-    })
+    });
   });
 });

--- a/lib/ZMQClient/methods/connect.spec.js
+++ b/lib/ZMQClient/methods/connect.spec.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const { Subscriber, Publisher } = require('zeromq');
 const { EventEmitter } = require('events');
 const connect = require('./connect');
+const { EventEmitter } = require('events');
 
 const client = Object.assign({
   protocol: 'tcp',

--- a/lib/ZMQClient/methods/connect.spec.js
+++ b/lib/ZMQClient/methods/connect.spec.js
@@ -2,7 +2,6 @@ const { expect } = require('chai');
 const { Subscriber, Publisher } = require('zeromq');
 const { EventEmitter } = require('events');
 const connect = require('./connect');
-const { EventEmitter } = require('events');
 
 const client = Object.assign({
   protocol: 'tcp',

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -42,6 +42,11 @@ export default class ZMQClient extends EventEmitter {
          * Overrides default port (29998)
          */
         port?: string;
+
+        /**
+         * Overrides protocol, host and port from uri (tcp://0.0.0.0:29998)
+         */
+        uri?: string
     });
 
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In usage of V5, we used to use ZMQ by passing a path, this allow to use either URI or basic host/port pair. 

## What was done?
<!--- Describe your changes in detail -->
- added ability to pass a uri as constructor params.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
