### PR TITLE
feat: add maxRetries and only return socket when connected

### DIFF
--- a/lib/ZMQClient/methods/connect.js
+++ b/lib/ZMQClient/methods/connect.js
@@ -1,5 +1,7 @@
-// eslint-disable-next-line
-const { Subscriber, SocketOptions } = require('zeromq');
+const { Subscriber } = require('zeromq');
+
+const runSocketMonitor = require('../utils/runSocketMonitor');
+const runSocketReceiver = require('../utils/runSocketReceiver');
 
 /**
  * Create a new Subscriber socket and connect to it.
@@ -9,20 +11,19 @@ const { Subscriber, SocketOptions } = require('zeromq');
  */
 async function connect(socketOption) {
   const self = this;
+  const uri = `${this.protocol}://${this.host}:${this.port}`;
 
-  // By default, we don't set any max
-  let maxRetries = -1;
+  // By default, we don't set any max number of retries
+  const maxRetries = socketOption.maxRetries || -1;
   let connectionRetries = 0;
 
   if (this.socket) {
     await this.disconnect();
   }
 
-  const uri = `${this.protocol}://${this.host}:${this.port}`;
   const opts = { ...socketOption };
 
-  if(opts.maxRetries){
-    maxRetries = opts.maxRetries;
+  if (opts.maxRetries) {
     // Subscriber opts is not extensible, we need to remove that from opts we pass
     delete opts.maxRetries;
   }
@@ -31,56 +32,43 @@ async function connect(socketOption) {
   this.socket = socket;
 
   return new Promise(async (resolve, reject) => {
-    await socket.connect(uri);
-
-    const runSocketMonitor = async function runSocketMonitor(){
-      for await (const event of socket.events) {
-        const type = event.type;
-        self.emit(type, event);
-      }
-    }
-
     // We only return socket when we actually established a connection
-    const onConnectionListener = function (){
+    function onConnectionListener() {
       self.isConnected = true;
       resolve(socket);
-    };
-    // If a max number of retries is set, we reject when exceeding retry number
-    const onRetryListener = async function (){
-      connectionRetries += 1;
-      if(connectionRetries > maxRetries){
-        await socket.disconnect(uri);
-        return reject(new Error('Connection dropped. Max retries exceeded.'));
-      }
     }
     self.on('connect', onConnectionListener);
 
-    if(maxRetries !== -1){
+    // If a max number of retries is set, we reject when exceeding retry number
+    if (maxRetries !== -1) {
+      const onRetryListener = async function onRetryListener() {
+        connectionRetries += 1;
+        if (connectionRetries > maxRetries) {
+          await socket.disconnect(uri);
+          return reject(new Error('Connection dropped. Max retries exceeded.'));
+        }
+        return true;
+      };
       self.on('connect:retry', onRetryListener);
     }
 
-    const runReceiver = async function runReceiver() {
-      try {
-        const [rawTopic, rawMsg] = await socket.receive();
-        const topic = rawTopic.toString('utf-8');
-        const message = rawMsg.toString('hex');
-        self.emit(topic, message);
-        await runReceiver();
-      } catch (e) {
+    await socket.connect(uri);
+
+    runSocketMonitor(socket, self).catch(e => e);
+
+    runSocketReceiver(socket, self)
+      .catch((e) => {
         switch (e.code) {
           case 'EAGAIN':
-            if (this.isConnected) { throw e; }
+            if (this.isConnected) {
+              throw e;
+            }
             break;
           default:
             throw e;
         }
-      }
-    };
-
-    runSocketMonitor();
-    runReceiver();
-
-    return socket;
+      });
   });
 }
+
 module.exports = connect;

--- a/lib/ZMQClient/methods/connect.js
+++ b/lib/ZMQClient/methods/connect.js
@@ -6,22 +6,22 @@ const runSocketReceiver = require('../utils/runSocketReceiver');
 /**
  * Create a new Subscriber socket and connect to it.
  *
- * @param {ConnectionOptions} [socketOption]
+ * @param {SocketOptions<Subscriber>} [socketOptions]
  * @returns {Promise<Subscriber>}
  */
-async function connect(socketOption = {}) {
+async function connect(socketOptions = {}) {
   const self = this;
   const uri = `${this.protocol}://${this.host}:${this.port}`;
 
   // By default, we don't set any max number of retries
-  const maxRetries = socketOption.maxRetries || -1;
+  const maxRetries = socketOptions.maxRetries || -1;
   let connectionRetries = 0;
 
   if (this.socket) {
     await this.disconnect(uri);
   }
 
-  const opts = { ...socketOption };
+  const opts = { ...socketOptions };
 
   if (opts.maxRetries) {
     // Subscriber opts is not extensible, we need to remove that from opts we pass

--- a/lib/ZMQClient/methods/connect.js
+++ b/lib/ZMQClient/methods/connect.js
@@ -9,7 +9,7 @@ const runSocketReceiver = require('../utils/runSocketReceiver');
  * @param {ConnectionOptions} [socketOption]
  * @returns {Promise<Subscriber>}
  */
-async function connect(socketOption) {
+async function connect(socketOption = {}) {
   const self = this;
   const uri = `${this.protocol}://${this.host}:${this.port}`;
 
@@ -17,8 +17,9 @@ async function connect(socketOption) {
   const maxRetries = socketOption.maxRetries || -1;
   let connectionRetries = 0;
 
+  console.log(this.socket);
   if (this.socket) {
-    await this.disconnect();
+    await this.disconnect(uri);
   }
 
   const opts = { ...socketOption };
@@ -60,7 +61,7 @@ async function connect(socketOption) {
       .catch((e) => {
         switch (e.code) {
           case 'EAGAIN':
-            if (this.isConnected) {
+            if (self.isConnected) {
               throw e;
             }
             break;

--- a/lib/ZMQClient/methods/connect.js
+++ b/lib/ZMQClient/methods/connect.js
@@ -17,7 +17,6 @@ async function connect(socketOption = {}) {
   const maxRetries = socketOption.maxRetries || -1;
   let connectionRetries = 0;
 
-  console.log(this.socket);
   if (this.socket) {
     await this.disconnect(uri);
   }
@@ -38,14 +37,21 @@ async function connect(socketOption = {}) {
       self.isConnected = true;
       resolve(socket);
     }
+    function onEndListener() {
+      self.isConnected = false;
+      resolve(socket);
+    }
     self.on('connect', onConnectionListener);
+    self.on('end', onEndListener);
 
     // If a max number of retries is set, we reject when exceeding retry number
     if (maxRetries !== -1) {
       const onRetryListener = async function onRetryListener() {
         connectionRetries += 1;
         if (connectionRetries > maxRetries) {
-          await socket.disconnect(uri);
+          if (self.isConnected) { await socket.disconnect(uri); }
+          await socket.close();
+          self.removeListener('connect:retry', onRetryListener);
           return reject(new Error('Connection dropped. Max retries exceeded.'));
         }
         return true;

--- a/lib/ZMQClient/methods/connect.js
+++ b/lib/ZMQClient/methods/connect.js
@@ -6,29 +6,24 @@ const runSocketReceiver = require('../utils/runSocketReceiver');
 /**
  * Create a new Subscriber socket and connect to it.
  *
- * @param {SocketOptions<Subscriber>} [socketOptions]
+ * @param {ClientConnectionOptions} [connectionOptions]
  * @returns {Promise<Subscriber>}
  */
-async function connect(socketOptions = {}) {
+async function connect(connectionOptions = {}) {
   const self = this;
   const uri = `${this.protocol}://${this.host}:${this.port}`;
 
   // By default, we don't set any max number of retries
-  const maxRetries = socketOptions.maxRetries || -1;
+  const maxRetries = connectionOptions.maxRetries || -1;
   let connectionRetries = 0;
 
   if (this.socket) {
     await this.disconnect(uri);
   }
 
-  const opts = { ...socketOptions };
+  const socketOptions = { ...connectionOptions.socketOptions };
 
-  if (opts.maxRetries) {
-    // Subscriber opts is not extensible, we need to remove that from opts we pass
-    delete opts.maxRetries;
-  }
-
-  const socket = new Subscriber(opts);
+  const socket = new Subscriber(socketOptions);
   this.socket = socket;
 
   return new Promise(async (resolve, reject) => {

--- a/lib/ZMQClient/methods/connect.js
+++ b/lib/ZMQClient/methods/connect.js
@@ -4,53 +4,83 @@ const { Subscriber, SocketOptions } = require('zeromq');
 /**
  * Create a new Subscriber socket and connect to it.
  *
- * @param {SocketOptions<Subscriber>} [socketOption]
+ * @param {ConnectionOptions} [socketOption]
  * @returns {Promise<Subscriber>}
  */
 async function connect(socketOption) {
   const self = this;
+
+  // By default, we don't set any max
+  let maxRetries = -1;
+  let connectionRetries = 0;
+
   if (this.socket) {
     await this.disconnect();
   }
-  const uri = `${this.protocol}://${this.host}:${this.port}`;
 
+  const uri = `${this.protocol}://${this.host}:${this.port}`;
   const opts = { ...socketOption };
+
+  if(opts.maxRetries){
+    maxRetries = opts.maxRetries;
+    // Subscriber opts is not extensible, we need to remove that from opts we pass
+    delete opts.maxRetries;
+  }
 
   const socket = new Subscriber(opts);
   this.socket = socket;
 
-  await socket.connect(uri);
+  return new Promise(async (resolve, reject) => {
+    await socket.connect(uri);
 
-  this.isConnected = true;
-
-  const runSocketMonitor = async function runSocketMonitor(){
-    for await (const event of socket.events) {
-      const type = event.type;
-      self.emit(type, event);
-    }
-  }
-
-  const runReceiver = async function runReceiver() {
-    try {
-      const [rawTopic, rawMsg] = await socket.receive();
-      const topic = rawTopic.toString('utf-8');
-      const message = rawMsg.toString('hex');
-      self.emit(topic, message);
-      await runReceiver();
-    } catch (e) {
-      switch (e.code) {
-        case 'EAGAIN':
-          if (this.isConnected) { throw e; }
-          break;
-        default:
-          throw e;
+    const runSocketMonitor = async function runSocketMonitor(){
+      for await (const event of socket.events) {
+        const type = event.type;
+        self.emit(type, event);
       }
     }
-  };
 
-  runSocketMonitor();
-  runReceiver();
+    // We only return socket when we actually established a connection
+    const onConnectionListener = function (){
+      self.isConnected = true;
+      resolve(socket);
+    };
+    // If a max number of retries is set, we reject when exceeding retry number
+    const onRetryListener = async function (){
+      connectionRetries += 1;
+      if(connectionRetries > maxRetries){
+        await socket.disconnect(uri);
+        return reject(new Error('Connection dropped. Max retries exceeded.'));
+      }
+    }
+    self.on('connect', onConnectionListener);
 
-  return socket;
+    if(maxRetries !== -1){
+      self.on('connect:retry', onRetryListener);
+    }
+
+    const runReceiver = async function runReceiver() {
+      try {
+        const [rawTopic, rawMsg] = await socket.receive();
+        const topic = rawTopic.toString('utf-8');
+        const message = rawMsg.toString('hex');
+        self.emit(topic, message);
+        await runReceiver();
+      } catch (e) {
+        switch (e.code) {
+          case 'EAGAIN':
+            if (this.isConnected) { throw e; }
+            break;
+          default:
+            throw e;
+        }
+      }
+    };
+
+    runSocketMonitor();
+    runReceiver();
+
+    return socket;
+  });
 }
 module.exports = connect;

--- a/lib/ZMQClient/methods/connect.spec.js
+++ b/lib/ZMQClient/methods/connect.spec.js
@@ -17,30 +17,28 @@ const uri = `${client.protocol}://${client.host}:${client.port}`;
 describe('ZMQClient - #connect', function suite() {
   this.timeout(5000);
   it('should create a ZMQ Subscriber', async () => {
-    setTimeout(()=>{
+    setTimeout(() => {
       client.socket.close();
-    }, 1000)
+    }, 1000);
     await connect.call(client);
     expect(client.socket).to.not.equal(null);
     expect(client.socket.constructor).to.be.equal(Subscriber);
   });
-  it('should have a max retries', async () => {
-    return new Promise(async (resolve, reject)=>{
-      try{
-        await connect.call(client, { maxRetries: 1 });
-        reject(new Error('Expected to reject with error'));
-      }catch (e){
-        expect(e.message).to.equal("Connection dropped. Max retries exceeded.");
-        resolve(true);
-      }
-    });
-  });
+  it('should have a max retries', async () => new Promise(async (resolve, reject) => {
+    try {
+      await connect.call(client, { maxRetries: 1 });
+      reject(new Error('Expected to reject with error'));
+    } catch (e) {
+      expect(e.message).to.equal('Connection dropped. Max retries exceeded.');
+      resolve(true);
+    }
+  }));
   it('should connect', async () => {
-    const publisher = new Publisher
-    await publisher.bind("tcp://127.0.0.1:29998");
+    const publisher = new Publisher();
+    await publisher.bind('tcp://127.0.0.1:29998');
     await connect.call(client, { maxRetries: 1 });
     expect(client.isConnected).to.equal(true);
-    publisher.disconnect("tcp://127.0.0.1:29998");
+    publisher.disconnect('tcp://127.0.0.1:29998');
   });
   after(async () => {
     client.isConnected = false;

--- a/lib/ZMQClient/methods/connect.spec.js
+++ b/lib/ZMQClient/methods/connect.spec.js
@@ -1,33 +1,46 @@
 const { expect } = require('chai');
-const { Subscriber } = require('zeromq');
+const { Subscriber, Publisher } = require('zeromq');
+const { EventEmitter } = require('events');
 const connect = require('./connect');
 
-const client = {
+const client = Object.assign({
   protocol: 'tcp',
   host: '0.0.0.0',
   port: '29998',
   socket: null,
   isConnected: false,
-};
+  disconnect: () => { client.isConnected = false; },
+}, EventEmitter.prototype);
+
 const uri = `${client.protocol}://${client.host}:${client.port}`;
 
-describe('ZMQClient - #connect', () => {
-  it('should connect to ZMQ', () => {
-    connect.call(client);
-    expect(client.socket).to.not.equal(null);
-  });
-  it('should disconnect and connect if a socket is open', async () => {
-    let disconnectionCalled = false;
-    client.disconnect = async function disconnectClient() {
-      disconnectionCalled = true;
-      client.isConnected = false;
-      await client.socket.disconnect(uri);
-      await client.socket.close();
-    };
+describe('ZMQClient - #connect', function suite() {
+  this.timeout(5000);
+  it('should create a ZMQ Subscriber', async () => {
+    setTimeout(()=>{
+      client.socket.close();
+    }, 1000)
     await connect.call(client);
-    expect(disconnectionCalled).to.equal(true);
-    expect(client.socket.constructor.name).to.equal(Subscriber.name);
+    expect(client.socket).to.not.equal(null);
+    expect(client.socket.constructor).to.be.equal(Subscriber);
+  });
+  it('should have a max retries', async () => {
+    return new Promise(async (resolve, reject)=>{
+      try{
+        await connect.call(client, { maxRetries: 1 });
+        reject(new Error('Expected to reject with error'));
+      }catch (e){
+        expect(e.message).to.equal("Connection dropped. Max retries exceeded.");
+        resolve(true);
+      }
+    });
+  });
+  it('should connect', async () => {
+    const publisher = new Publisher
+    await publisher.bind("tcp://127.0.0.1:29998");
+    await connect.call(client, { maxRetries: 1 });
     expect(client.isConnected).to.equal(true);
+    publisher.disconnect("tcp://127.0.0.1:29998");
   });
   after(async () => {
     client.isConnected = false;

--- a/lib/ZMQClient/utils/runSocketMonitor.js
+++ b/lib/ZMQClient/utils/runSocketMonitor.js
@@ -1,3 +1,9 @@
+/**
+ * SocketMonitor will listen for all event and emit them to those listening
+ * @param socket
+ * @param emitter
+ * @returns {Promise<void>}
+ */
 const runSocketMonitor = async function runSocketMonitor(socket, emitter) {
   // eslint-disable-next-line no-restricted-syntax
   for await (const event of socket.events) {

--- a/lib/ZMQClient/utils/runSocketMonitor.js
+++ b/lib/ZMQClient/utils/runSocketMonitor.js
@@ -1,0 +1,8 @@
+const runSocketMonitor = async function runSocketMonitor(socket, emitter) {
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const event of socket.events) {
+    const { type } = event;
+    emitter.emit(type, event);
+  }
+};
+module.exports = runSocketMonitor;

--- a/lib/ZMQClient/utils/runSocketReceiver.js
+++ b/lib/ZMQClient/utils/runSocketReceiver.js
@@ -1,0 +1,8 @@
+const runSocketReceiver = async function runSocketReceiver(socket, emitter) {
+  const [rawTopic, rawMsg] = await socket.receive();
+  const topic = rawTopic.toString('utf-8');
+  const message = rawMsg.toString('hex');
+  emitter.emit(topic, message);
+  await runSocketReceiver();
+};
+module.exports = runSocketReceiver;

--- a/lib/ZMQClient/utils/runSocketReceiver.js
+++ b/lib/ZMQClient/utils/runSocketReceiver.js
@@ -1,8 +1,15 @@
+/**
+ * SocketReceiver will listen for receivable message, and return message to listeners of the topic.
+ *
+ * @param socket
+ * @param emitter
+ * @returns {Promise<void>}
+ */
 const runSocketReceiver = async function runSocketReceiver(socket, emitter) {
   const [rawTopic, rawMsg] = await socket.receive();
   const topic = rawTopic.toString('utf-8');
   const message = rawMsg.toString('hex');
   emitter.emit(topic, message);
-  await runSocketReceiver();
+  await runSocketReceiver(socket, emitter);
 };
 module.exports = runSocketReceiver;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -63,10 +63,10 @@ export default class ZMQClient extends EventEmitter {
     /**
      * Create a new Subscriber socket and connect to it.
      *
-     * @param {ConnectionOptions} [socketOption]
+     * @param {SocketOptions<Subscriber>} [socketOptions]
      * @returns {Promise<Subscriber>}
      */
-    connect(socketOption?: ConnectionOptions): Promise<Subscriber>;
+    connect(socketOptions?: SocketOptions<Subscriber>): Promise<Subscriber>;
 
     /**
      * Disconnect socket from ZMQ.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -20,8 +20,9 @@ interface TopicsTypeMap {
     rawinstantsenddoublespend: 'rawinstantsenddoublespend';
 }
 
-interface ConnectionOptions extends SocketOptions<Subscriber> {
-  maxRetries?: number
+export interface ClientConnectionOptions {
+  maxRetries?: number,
+  socketOptions: SocketOptions<Subscriber>
 }
 
 /**
@@ -63,10 +64,10 @@ export default class ZMQClient extends EventEmitter {
     /**
      * Create a new Subscriber socket and connect to it.
      *
-     * @param {SocketOptions<Subscriber>} [socketOptions]
+     * @param {ClientConnectionOptions} [connectionOptions]
      * @returns {Promise<Subscriber>}
      */
-    connect(socketOptions?: SocketOptions<Subscriber>): Promise<Subscriber>;
+    connect(connectionOptions?: ClientConnectionOptions): Promise<Subscriber>;
 
     /**
      * Disconnect socket from ZMQ.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -20,6 +20,10 @@ interface TopicsTypeMap {
     rawinstantsenddoublespend: 'rawinstantsenddoublespend';
 }
 
+interface ConnectionOptions extends SocketOptions<Subscriber> {
+  maxRetries?: number
+}
+
 /**
  * @class ZMQClient
  */
@@ -59,10 +63,10 @@ export default class ZMQClient extends EventEmitter {
     /**
      * Create a new Subscriber socket and connect to it.
      *
-     * @param {SocketOptions<Subscriber>} [socketOption]
+     * @param {ConnectionOptions} [socketOption]
      * @returns {Promise<Subscriber>}
      */
-    connect(socketOption?: SocketOptions<Subscriber>): Promise<Subscriber>;
+    connect(socketOption?: ConnectionOptions): Promise<Subscriber>;
 
     /**
      * Disconnect socket from ZMQ.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In Insight, in usage, we actually expect to be able to await for the connectivity. 
Therefore this PR adds the resolvement of the `.connect` tied to the condition of us actually succeeding to connect. 
To provide a better handling from client side, we also added `.maxRetries` a new options extending SocketOptions which is now called ConnectionOptions. 

## What was done?
<!--- Describe your changes in detail -->
- feat: created ConnectionOptions interface that extends SocketOptions
- feat: add maxRetries
- feat: resolvement of .connect tried to actually connecting to a Publisher.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
